### PR TITLE
fix: infra_id_ initialize

### DIFF
--- a/include/cargo_loading_service/cargo_loading_service.hpp
+++ b/include/cargo_loading_service/cargo_loading_service.hpp
@@ -49,6 +49,7 @@ private:
   // variable
   uint8_t infra_id_;
   int32_t aw_state_{InParkingStatus::NONE};
+  int32_t vehicle_operation_mode_{InParkingStatus::VEHICLE_MANUAL};
   bool infra_approval_{false};
   uint8_t service_result_{ExecuteInParkingTask::Response::NONE};
   double command_pub_hz_;

--- a/include/cargo_loading_service/cargo_loading_service.hpp
+++ b/include/cargo_loading_service/cargo_loading_service.hpp
@@ -46,11 +46,10 @@ private:
   // constants
   enum class CommandState : uint8_t { REQUESTING = 0b01, ERROR = 0b10 };
 
-
   // variable
   uint8_t infra_id_;
   int32_t aw_state_{InParkingStatus::NONE};
-  bool infra_approval_;
+  bool infra_approval_{false};
   uint8_t service_result_{ExecuteInParkingTask::Response::NONE};
   double command_pub_hz_;
   double post_processing_time_;

--- a/src/cargo_loading_service.cpp
+++ b/src/cargo_loading_service.cpp
@@ -158,6 +158,7 @@ void CargoLoadingService::onTimer()
       rclcpp::sleep_for(rclcpp::Rate(command_pub_hz_).period());
     }
     infra_approval_ = false;
+    infra_id_ = InfrastructureState::INVALID_ID;
     timer_->cancel();
   }
 }

--- a/src/cargo_loading_service.cpp
+++ b/src/cargo_loading_service.cpp
@@ -53,7 +53,7 @@ CargoLoadingService::CargoLoadingService(const rclcpp::NodeOptions & options)
     "/in_parking/state", rclcpp::QoS{1},
     std::bind(&CargoLoadingService::onInParkingStatus, this, _1), subscribe_option);
   sub_infrastructure_status_ = this->create_subscription<InfrastructureStateArray>(
-    "/v2i/infrastructure_status", rclcpp::QoS{1},
+    "/v2i/infrastructure_states", rclcpp::QoS{1},
     std::bind(&CargoLoadingService::onInfrastructureStatus, this, _1), subscribe_option);
 
   // timer

--- a/src/cargo_loading_service.cpp
+++ b/src/cargo_loading_service.cpp
@@ -53,7 +53,7 @@ CargoLoadingService::CargoLoadingService(const rclcpp::NodeOptions & options)
     "/in_parking/state", rclcpp::QoS{1},
     std::bind(&CargoLoadingService::onInParkingStatus, this, _1), subscribe_option);
   sub_infrastructure_status_ = this->create_subscription<InfrastructureStateArray>(
-    "/infrastructure_status", rclcpp::QoS{1},
+    "/v2i/infrastructure_status", rclcpp::QoS{1},
     std::bind(&CargoLoadingService::onInfrastructureStatus, this, _1), subscribe_option);
 
   // timer

--- a/src/cargo_loading_service.cpp
+++ b/src/cargo_loading_service.cpp
@@ -41,7 +41,7 @@ CargoLoadingService::CargoLoadingService(const rclcpp::NodeOptions & options)
 
   // Service
   srv_cargo_loading_ = proxy.create_service<ExecuteInParkingTask>(
-    "/parking/cargo_loading", std::bind(&CargoLoadingService::execCargoLoading, this, _1, _2),
+    "/in_parking/task", std::bind(&CargoLoadingService::execCargoLoading, this, _1, _2),
     rmw_qos_profile_services_default, callback_group_service_);
 
   // Publisher

--- a/src/cargo_loading_service.cpp
+++ b/src/cargo_loading_service.cpp
@@ -179,8 +179,17 @@ void CargoLoadingService::onInfrastructureStatus(const InfrastructureStateArray:
   const auto itr = std::find_if(msg->states.begin(), msg->states.end(), [this](const auto & e) {
     return e.id == infra_id_;
   });
+
   if (itr != msg->states.end()) {
-    infra_approval_ = (msg->states.at(std::distance(msg->states.begin(), itr)).state == static_cast<uint8_t>(CommandState::ERROR));
+    const auto &e = msg->states.at(std::distance(msg->states.begin(), itr));
+
+    // 成功した場合、0b01が返ってくる
+    infra_approval_ = (e.state == 0b01);
+
+    // 0b01じゃない場合、エラー出力
+    if (e.state != 0b01) {
+      RCLCPP_ERROR(this->get_logger(), "invalid return value: %d", e.state);
+    }
   }
 
   RCLCPP_DEBUG_THROTTLE(

--- a/src/cargo_loading_service.cpp
+++ b/src/cargo_loading_service.cpp
@@ -114,14 +114,6 @@ void CargoLoadingService::onTimer()
 {
   RCLCPP_INFO(this->get_logger(), "timer start");
 
-// aw_stateのsubscribe確認、NONEならばreject
-  if (aw_state_ == InParkingStatus::NONE) {
-    RCLCPP_WARN(this->get_logger(), "aw_state is NONE, reject...");
-    service_result_ = ExecuteInParkingTask::Response::FAIL;
-    timer_->cancel();
-    return;
-  }
-
   // 設備連携が完了していない
   if (!infra_approval_) {
     // aw_stateで条件分岐


### PR DESCRIPTION
Because the ID of the completed facility is not cleared when the facility linkage is completed,
Added clear processing.

At the stop, it was confirmed that the completion notification of different equipment was not completed even if it was received.