### PR TITLE
fix: add log output locations and change output level in one location

### DIFF
--- a/src/cargo_loading_service.cpp
+++ b/src/cargo_loading_service.cpp
@@ -149,7 +149,7 @@ void CargoLoadingService::onTimer()
         break;
     }
   } else {  // 設備連携が完了
-    RCLCPP_INFO(this->get_logger(), "finishing");
+    RCLCPP_INFO(this->get_logger(), "try reporting to infrastructure that the cargo loading process is over.");
     // SEND_ZEROをn秒間発出し、設備連携結果はSUCCESSで返し、timerをキャンセル
     const auto start_time = this->now();
     while (true) {

--- a/src/cargo_loading_service.cpp
+++ b/src/cargo_loading_service.cpp
@@ -158,7 +158,7 @@ void CargoLoadingService::onTimer()
       if (time_diff.seconds() > post_processing_time_) break;
       rclcpp::sleep_for(rclcpp::Rate(command_pub_hz_).period());
     }
-    RCLCPP_INFO(this->get_logger(), "finished");
+    RCLCPP_INFO(this->get_logger(), "complete reporting to infrastructure that the cargo loading process is over.");
     infra_approval_ = false;
     infra_id_ = InfrastructureState::INVALID_ID;
     timer_->cancel();

--- a/src/cargo_loading_service.cpp
+++ b/src/cargo_loading_service.cpp
@@ -119,7 +119,8 @@ void CargoLoadingService::onTimer()
       // AWがEmergencyの場合はERRORを発出し続ける
       case InParkingStatus::AW_EMERGENCY:
         publishCommand(static_cast<std::underlying_type<CommandState>::type>(CommandState::ERROR));
-        RCLCPP_ERROR(this->get_logger(), "AW emergency");
+        RCLCPP_ERROR_THROTTLE(
+          this->get_logger(), *this->get_clock(), 1000 /* ms */, "AW emergency");
         break;
       // AWが停留所外などではinfra_approvalをtrueにし、設備連携結果はFAILで返す
       case InParkingStatus::AW_OUT_OF_PARKING:
@@ -148,7 +149,7 @@ void CargoLoadingService::onTimer()
         break;
     }
   } else {  // 設備連携が完了
-    RCLCPP_DEBUG(this->get_logger(), "finished");
+    RCLCPP_INFO(this->get_logger(), "finishing");
     // SEND_ZEROをn秒間発出し、設備連携結果はSUCCESSで返し、timerをキャンセル
     const auto start_time = this->now();
     while (true) {
@@ -157,6 +158,7 @@ void CargoLoadingService::onTimer()
       if (time_diff.seconds() > post_processing_time_) break;
       rclcpp::sleep_for(rclcpp::Rate(command_pub_hz_).period());
     }
+    RCLCPP_INFO(this->get_logger(), "finished");
     infra_approval_ = false;
     infra_id_ = InfrastructureState::INVALID_ID;
     timer_->cancel();

--- a/src/cargo_loading_service.cpp
+++ b/src/cargo_loading_service.cpp
@@ -126,7 +126,7 @@ void CargoLoadingService::onTimer()
       case InParkingStatus::AW_OUT_OF_PARKING:
       case InParkingStatus::AW_UNAVAILABLE:
       case InParkingStatus::NONE:
-        RCLCPP_WARN(this->get_logger(), "AW_OUT_OF_PARKING or AW_UNAVAILABLE or NONE");
+        RCLCPP_INFO(this->get_logger(), "AW_OUT_OF_PARKING or AW_UNAVAILABLE or NONE");
         infra_approval_ = true;
         service_result_ = ExecuteInParkingTask::Response::FAIL;
         break;
@@ -140,7 +140,7 @@ void CargoLoadingService::onTimer()
           publishCommand(
           static_cast<std::underlying_type<CommandState>::type>(CommandState::REQUESTING));
         } else {  // 車両が手動モードならinfra_approvalをtrueにし、設備連携結果はFAILで返す
-          RCLCPP_WARN(this->get_logger(), "vehicle is manual mode");
+          RCLCPP_INFO(this->get_logger(), "vehicle is manual mode");
           infra_approval_ = true;
           service_result_ = ExecuteInParkingTask::Response::FAIL;
         }


### PR DESCRIPTION
## Description
<!-- Write a brief description of this PR. -->

This PR improves the log output of cargo_loading_service.

* Changed the method of log output in Emergency status from `RCLCPP_ERROR()` to `RCLCPP_ERROR_THROTTLE()`.
* Changed log output level from `DEBUG` to `INFO` when cargo loading is finished.
* Added log output after sending cargo loading finish command.

## Related links
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

* Jira ticket
    * [Ticket (COMPANY INTERNAL LINK)]

[Ticket (COMPANY INTERNAL LINK)]: https://tier4.atlassian.net/browse/T4PB-26318

## Tests performed

The tests described below were conducted.

* Verified that the package can be built without Error/Warning by `colcon`.
* Verified that the changed/added logs are output as described in the Test Case.

<details><summary>Test Case</summary>
<p>

| No |Description|
|----|---|
| 1 |A log showing the status of the status shall be output every second during the status of the EMERGENCY. |
| 2 |Logging should be output at the INFO level before the completion of the process that ends cargo loading.|
| 3 |Logs should be output at the INFO level after the completion of the process that ends cargo loading.|

</p>
</details>

## Notes for reviewers
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

None.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
