### PR TITLE
fix vehicle is manual mode continue process

### DIFF
--- a/src/cargo_loading_service.cpp
+++ b/src/cargo_loading_service.cpp
@@ -126,7 +126,7 @@ void CargoLoadingService::onTimer()
     switch (aw_state_) {
       // AWがEmergencyの場合はERRORを発出し続ける
       case InParkingStatus::AW_EMERGENCY:
-        publishCommand(static_cast<std::underlying_type<CommandState>::type>(CommandState::ERROR));
+        publishCommand(static_cast<uint8_t>(CommandState::ERROR));
         RCLCPP_ERROR_THROTTLE(
           this->get_logger(), *this->get_clock(), 1000 /* ms */, "AW emergency");
         break;
@@ -143,8 +143,7 @@ void CargoLoadingService::onTimer()
       case InParkingStatus::AW_WAITING_FOR_ENGAGE:
       case InParkingStatus::AW_ARRIVED_PARKING:
         RCLCPP_DEBUG(this->get_logger(), "requesting");
-        publishCommand(
-        static_cast<std::underlying_type<CommandState>::type>(CommandState::REQUESTING));
+        publishCommand(static_cast<uint8_t>(CommandState::REQUESTING));
         break;
       default:
         break;

--- a/src/cargo_loading_service.cpp
+++ b/src/cargo_loading_service.cpp
@@ -142,16 +142,9 @@ void CargoLoadingService::onTimer()
       case InParkingStatus::AW_WAITING_FOR_ROUTE:
       case InParkingStatus::AW_WAITING_FOR_ENGAGE:
       case InParkingStatus::AW_ARRIVED_PARKING:
-        // 車両が自動モードなら設備連携要求を発出
-        if (vehicle_operation_mode_ == InParkingStatus::VEHICLE_AUTO) {
-          RCLCPP_DEBUG(this->get_logger(), "requesting");
-          publishCommand(
-          static_cast<std::underlying_type<CommandState>::type>(CommandState::REQUESTING));
-        } else {  // 車両が手動モードならinfra_approvalをtrueにし、設備連携結果はFAILで返す
-          RCLCPP_INFO(this->get_logger(), "vehicle is manual mode");
-          infra_approval_ = true;
-          service_result_ = ExecuteInParkingTask::Response::FAIL;
-        }
+        RCLCPP_DEBUG(this->get_logger(), "requesting");
+        publishCommand(
+        static_cast<std::underlying_type<CommandState>::type>(CommandState::REQUESTING));
         break;
       default:
         break;


### PR DESCRIPTION
## Description:
Changing to manual mode during cargo loading will interrupt the cargo loading process.
This specification needs improvement in terms of availability.

In this PR, I changed the specification so that processing can continue even in manual mode.

## Tests performed
- Confirmed that processing continues even in manual mode of vehicle mode
- Build success