### PR TITLE
extend in_parking state timeout  threshold

### DIFF
--- a/include/cargo_loading_service/cargo_loading_service.hpp
+++ b/include/cargo_loading_service/cargo_loading_service.hpp
@@ -48,7 +48,6 @@ private:
   enum class CommandState : uint8_t { REQUESTING = 0b01, ERROR = 0b10 };
   enum class ReceiveState : uint8_t { APPROVAL = 0b01 };
   enum class InfraIdLimit : uint8_t { MIN = 1, MAX = 254 };
-  static constexpr double INPARKING_STATE_CHECK_TIMEOUT_SEC{0.2};
   static constexpr double INPARKING_STATE_CHECK_TIMEOUT_HZ{10.0};
   static constexpr double COMMAND_PUBLISH_HZ{5.0};
   static constexpr double COMMAND_DURATION_MIN_SEC{2.0};
@@ -60,6 +59,9 @@ private:
   bool infra_approval_{false};
   uint8_t service_result_{ExecuteInParkingTask::Response::NONE};
   rclcpp::Time aw_state_last_receive_time_{rclcpp::Time(0)};
+
+  // Parameter
+  double inparking_state_check_timeout_sec_;
 
   // Service
   tier4_api_utils::Service<ExecuteInParkingTask>::SharedPtr srv_cargo_loading_;

--- a/launch/cargo_loading_service.launch.xml
+++ b/launch/cargo_loading_service.launch.xml
@@ -15,6 +15,8 @@
 -->
 
 <launch>
+  <arg name="inparking_state_check_timeout_sec" default="5.0"/>
   <node pkg="cargo_loading_service" exec="cargo_loading_service" name="cargo_loading_service" output="screen">
+    <param name="inparking_state_check_timeout_sec" value="$(var inparking_state_check_timeout_sec)"/>
   </node>
 </launch>

--- a/src/cargo_loading_service.cpp
+++ b/src/cargo_loading_service.cpp
@@ -27,6 +27,10 @@ CargoLoadingService::CargoLoadingService(const rclcpp::NodeOptions & options)
   using std::placeholders::_2;
   tier4_api_utils::ServiceProxyNodeInterface proxy(this);
 
+  // rosparam
+  inparking_state_check_timeout_sec_ =
+  declare_parameter<double>("inparking_state_check_timeout_sec", 5.0);
+
   // Callback group
   callback_group_subscription_ =
     this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
@@ -173,7 +177,7 @@ void CargoLoadingService::onTimeoutCheckTimer()
   }
 
   auto receive_time_diff = get_clock()->now() - aw_state_last_receive_time_;
-  if (receive_time_diff.seconds() > INPARKING_STATE_CHECK_TIMEOUT_SEC) {
+  if (receive_time_diff.seconds() > inparking_state_check_timeout_sec_) {
     aw_state_ = InParkingStatus::AW_EMERGENCY;
     RCLCPP_ERROR(
       this->get_logger(), "/in_parking/state receive timeout. Last received time (seconds) = %lf",


### PR DESCRIPTION
## Description

本PRは、停留所で設備との通信が意図せず失敗し稼働が止まってしまう問題への対策である。

### 課題の概要と対策方針
調査の結果、車両システムの負荷増大などを起因とした設備連携失敗を早期に検出するためのハートビート監視の設定（途絶検知時間）が過剰に厳しく設定されていたことが本問題を誘発していたことが明らかとなった。
よって今回の対策としては運用で許容される範囲でこの設定を延長する方針とする。

### 対策内容
#### 途絶検知時間設定の延長
運用で許容される途絶検知時間の範囲は「設備連携の稼働維持」と「ユーザーの待機時間」の２つの観点で決定される。
- 設備連携の稼働維持観点
  - 想定される途絶を検知して停車する異常
途絶検知時間は１秒を超える必要がある。
過去実績より0.2〜0.5秒程度の途絶が確認されている。マージンを取って１秒を超える途絶検知時間にする必要がある。
 
  - 通常想定されない途絶が発生した際の停留場設備連携における状態遷移の仕様限界
途絶検知時間は6.8秒以下である必要がある。
本機能は停車時に開始するため停車後次に発車するまでに途絶が解消されないと稼働が維持されない可能性がある。
到着後次の発車準備が完了するまでの時間を調査した結果6.8秒以下である確率が極めて高い。
調査資料は[こちら(Company Internal Link)](https://docs.google.com/spreadsheets/d/1jpdzBkjp5t6NEs_Asxj_EdTAvI04Wy5rxmDfZnSzdik/edit#gid=1151973951)

- ユーザーの待機時間観点
途絶検知時間は６０秒未満である必要がある。
「数年に１度あるかないかの頻度でユーザが停車からエラー通知まで60秒間待ち続けること」は運用で許容される。
途絶検知してからエラー通知までのタイムラグはミリ秒オーダーであることから途絶検知時間は60秒未満と言える。
[こちら(Company Internal Link)](https://star4.slack.com/archives/C017JDNQCMV/p1716957453053169)

以上より１秒を超えて6.8秒以下が想定される稼働維持が可能な途絶検知時間である。
稼働維持率を高めるため長い時間を設定することが好ましい、途絶時間にはばらつきが想定されるためマージンを持って５秒を設定する。

### 実装内容
・パラメータのdefault値を変更
・パラメータを外部から指定出来るようにする

#### default値の変更
実装方法としては、default値を変更する、しない（外部からパラメータ指定）の２つの実装方法がある。
設定値の延長による既存ユーザへの悪影響が極めて小さく、恩恵が極めて大きいと判断できることからdefault値の変更を実施する。
- メリット : 意図せぬ設備連携異常による稼働停止の発生頻度が極めて少なくなる。
- デメリット : 正常系への影響はなし。異常系にてユーザ待機時間が閾値時間の延長分増加する。

#### パラメータ値変更のためのユーザインタフェース提供
本リポジトリは設備を制御する役割を持つOSSであることから、
今回機能についてユーザごとに微調整する機能を提供するためのインタフェースを用意する。


## Related links
- [Ticket(Company internal link)](https://tier4.atlassian.net/browse/AEAP-1128)

## Tests performed
### 問題解決の確認
1. 停留場設備連携開始後、５秒未満の途絶した後復帰させた場合はエラー状態とならずに/cargo_loading/infrastructure_commandsのステータスがCommandState::REQUESTING(１)のままであることを確認済み

### 実装内容の確認
#### パラメータのdefault値を変更
2. 停留場設備連携開始後、/in_parking/stateを５秒間途絶させたらエラー状態となり/cargo_loading/infrastructure_commandsのステータスがCommandState::ERROR(2)になることを確認済み
#### パラメータを外部から指定出来るようにする
3. 以下のコマンドを実行して「5.0」が返って来ることを確認済み
`ros2 param get /cargo_loading_service inparking_state_check_timeout_sec`
4. lauchファイルのinparking_state_check_timeout_secを変更した際に途絶検知までの時間が変わることを確認済み
確認した時間：0.2秒、60秒

### リグレッション確認
本変更は条件のパラメータ化とデフォルト値変更でロジックへの変更は無いためリグレッションがないと判断できる。

### 結論
この結果から本PRが対象とする問題が解決されるものと判断出来る

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/